### PR TITLE
fix: TikZJax dark-mode text rendering and font loading

### DIFF
--- a/media/tikz-preview.css
+++ b/media/tikz-preview.css
@@ -1,5 +1,8 @@
 /* TikZ diagram styles for VS Code built-in Markdown preview */
 
+/* Load Computer Modern fonts used by node-tikzjax SVG output. */
+@import url("../node_modules/node-tikzjax/css/fonts.css");
+
 .tikz-diagram {
     margin: 1.5em 0;
     padding: 16px;

--- a/src/utils/colorTransform.test.ts
+++ b/src/utils/colorTransform.test.ts
@@ -137,6 +137,50 @@ describe('transformSvgColors', () => {
                 const result = transformSvgColors(svg, true);
                 expect(result).toBe('<rect fill="#ff0000" stroke="#00ff00" />');
             });
+
+            it('should transform colors inside inline style attributes', () => {
+                const svg = '<path style="fill:#000; stroke: rgb(255, 255, 255); color:black" />';
+                const result = transformSvgColors(svg, true);
+                const bgColor = 'var(--vscode-editor-background)';
+
+                expect(result).toContain('fill:currentColor');
+                expect(result).toContain(`stroke: ${bgColor}`);
+                expect(result).toContain('color:currentColor');
+            });
+
+            it('should transform single-quoted SVG color attributes', () => {
+                const svg = "<g fill='#000000' stroke='white' color='rgb(0,0,0)'></g>";
+                const result = transformSvgColors(svg, true);
+                const bgColor = 'var(--vscode-editor-background)';
+
+                expect(result).toContain('fill="currentColor"');
+                expect(result).toContain(`stroke="${bgColor}"`);
+                expect(result).toContain('color="currentColor"');
+            });
+
+            it('should set currentColor for text without explicit fill', () => {
+                // Common TikZJax shape: text has stroke set, but no fill/color attribute.
+                const svg = '<text x="0" y="0" stroke="none">Hello</text>';
+                const result = transformSvgColors(svg, true);
+
+                expect(result).toContain('fill="currentColor"');
+            });
+
+            it('should set currentColor for tikzjax text-like output', () => {
+                // Targeted regression test requested by user: minimal text node from renderer.
+                const svg = '<text stroke="none">H</text>';
+                const result = transformSvgColors(svg, true);
+
+                expect(result).toBe('<text stroke="none" fill="currentColor">H</text>');
+            });
+
+            it('should keep explicit text fill behavior unchanged', () => {
+                // Explicit fill should continue to flow through existing white/black replacement logic.
+                const svg = '<text fill="#fff">Hello</text>';
+                const result = transformSvgColors(svg, true);
+
+                expect(result).toBe('<text fill="var(--vscode-editor-background)">Hello</text>');
+            });
         });
 
         describe('edge cases', () => {

--- a/src/utils/colorTransform.ts
+++ b/src/utils/colorTransform.ts
@@ -20,40 +20,67 @@ export function transformSvgColors(svg: string, darkMode: boolean): string {
         return svg;
     }
 
+    // Replace black/white color values in both direct SVG attributes and inline style blocks.
+    // This covers TikZJax outputs where colors may be emitted as attributes or style declarations.
     let transformed = svg;
-
-    // Replace black colors with currentColor (Requirement 7.1)
-    // Handle various black color formats: #000, #000000, rgb(0,0,0), black
-    transformed = transformed
-        .replace(/fill="#000000"/g, 'fill="currentColor"')
-        .replace(/fill="#000"/g, 'fill="currentColor"')
-        .replace(/fill="black"/g, 'fill="currentColor"')
-        .replace(/fill="rgb\(0,\s*0,\s*0\)"/g, 'fill="currentColor"')
-        .replace(/stroke="#000000"/g, 'stroke="currentColor"')
-        .replace(/stroke="#000"/g, 'stroke="currentColor"')
-        .replace(/stroke="black"/g, 'stroke="currentColor"')
-        .replace(/stroke="rgb\(0,\s*0,\s*0\)"/g, 'stroke="currentColor"')
-        .replace(/color="#000000"/g, 'color="currentColor"')
-        .replace(/color="#000"/g, 'color="currentColor"')
-        .replace(/color="black"/g, 'color="currentColor"')
-        .replace(/color="rgb\(0,\s*0,\s*0\)"/g, 'color="currentColor"');
-
-    // Replace white colors with background color variable (Requirement 7.2)
-    // Handle various white color formats: #fff, #ffffff, rgb(255,255,255), white
     const bgColor = 'var(--vscode-editor-background)';
-    transformed = transformed
-        .replace(/fill="#ffffff"/gi, `fill="${bgColor}"`)
-        .replace(/fill="#fff"/gi, `fill="${bgColor}"`)
-        .replace(/fill="white"/g, `fill="${bgColor}"`)
-        .replace(/fill="rgb\(255,\s*255,\s*255\)"/g, `fill="${bgColor}"`)
-        .replace(/stroke="#ffffff"/gi, `stroke="${bgColor}"`)
-        .replace(/stroke="#fff"/gi, `stroke="${bgColor}"`)
-        .replace(/stroke="white"/g, `stroke="${bgColor}"`)
-        .replace(/stroke="rgb\(255,\s*255,\s*255\)"/g, `stroke="${bgColor}"`)
-        .replace(/color="#ffffff"/gi, `color="${bgColor}"`)
-        .replace(/color="#fff"/gi, `color="${bgColor}"`)
-        .replace(/color="white"/g, `color="${bgColor}"`)
-        .replace(/color="rgb\(255,\s*255,\s*255\)"/g, `color="${bgColor}"`);
+
+    const blackPatterns = ['#000000', '#000', 'black', 'rgb\\(0,\\s*0,\\s*0\\)'];
+    const whitePatterns = ['#ffffff', '#fff', 'white', 'rgb\\(255,\\s*255,\\s*255\\)'];
+    const colorAttrs = ['fill', 'stroke', 'color'];
+
+    const replaceColorAttrs = (input: string, patterns: string[], replacement: string): string => {
+        let out = input;
+        for (const attr of colorAttrs) {
+            for (const pattern of patterns) {
+                out = out.replace(new RegExp(`${attr}="${pattern}"`, 'gi'), `${attr}="${replacement}"`);
+                out = out.replace(new RegExp(`${attr}='${pattern}'`, 'gi'), `${attr}="${replacement}"`);
+            }
+        }
+        return out;
+    };
+
+    const replaceInlineStyleColors = (input: string, patterns: string[], replacement: string): string => {
+        let out = input;
+        for (const attr of colorAttrs) {
+            for (const pattern of patterns) {
+                out = out.replace(
+                    new RegExp(`(${attr}\\s*:\\s*)${pattern}(\\s*;?)`, 'gi'),
+                    `$1${replacement}$2`
+                );
+            }
+        }
+        return out;
+    };
+
+    transformed = replaceColorAttrs(transformed, blackPatterns, 'currentColor');
+    transformed = replaceColorAttrs(transformed, whitePatterns, bgColor);
+
+    transformed = replaceInlineStyleColors(transformed, blackPatterns, 'currentColor');
+    transformed = replaceInlineStyleColors(transformed, whitePatterns, bgColor);
+
+    // TikZJax text often relies on SVG's default black fill (without explicit fill attr).
+    // In dark mode, make those text nodes inherit the editor foreground color.
+    transformed = transformed.replace(/<text\b([^>]*)>/gi, (fullTag, attrs) => {
+        // Keep explicit author intent untouched: only patch truly implicit text color.
+        if (/\/\s*>$/.test(fullTag)) {
+            return fullTag;
+        }
+        if (/\bfill\s*=\s*(['"]).*?\1/i.test(attrs)) {
+            return fullTag;
+        }
+        if (/\bcolor\s*=\s*(['"]).*?\1/i.test(attrs)) {
+            return fullTag;
+        }
+        if (/\bstyle\s*=\s*(['"])[\s\S]*?\bfill\s*:/i.test(attrs)) {
+            return fullTag;
+        }
+        if (/\bstyle\s*=\s*(['"])[\s\S]*?\bcolor\s*:/i.test(attrs)) {
+            return fullTag;
+        }
+        // Minimal fallback for dark themes: default black text -> current editor foreground.
+        return fullTag.replace(/>$/, ' fill="currentColor">');
+    });
 
     return transformed;
 }


### PR DESCRIPTION
* Load node-tikzjax's Computer Modern font CSS in the Markdown preview so SVG text uses the intended TeX fonts instead of falling back to system sans-serif fonts.

* Extend SVG color transformation to cover inline style declarations as well as direct fill, stroke, and color attributes. Add a minimal fallback for text nodes that rely on SVG's default black fill so dark themes render them with currentColor.

* Keep the existing stroke color transformation behavior intact and add regression tests for TikZJax-like text output, inline styles, and quoted attributes.